### PR TITLE
fix: Deleting and updating of status

### DIFF
--- a/controllers/aiven_application/reconciler.go
+++ b/controllers/aiven_application/reconciler.go
@@ -96,9 +96,7 @@ func (r *AivenApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	if err != nil {
 		utils.LocalFail("HandleProtectedAndTimeLimited", &application, err, logger)
 		return fail(err)
-	}
-
-	if applicationDeleted {
+	} else if applicationDeleted {
 		return ctrl.Result{}, nil
 	}
 


### PR DESCRIPTION
Logics for deleting an application need to be exe. and returned (if deleted) before processing and setting statuses, or aivenator will try to add status/updates to a none-existing application.