### PR TITLE
add securityContext to deployment.

### DIFF
--- a/charts/aivenator/templates/deployment.yaml
+++ b/charts/aivenator/templates/deployment.yaml
@@ -21,7 +21,17 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+            capabilities:
+              drop:
+                - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 1069
+            runAsNonRoot: true
+            runAsUser: 1069
+            allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:

--- a/charts/aivenator/values.yaml
+++ b/charts/aivenator/values.yaml
@@ -15,19 +15,6 @@ resources:
     cpu: 200m
     memory: 512Mi
 
-securityContext:
-  capabilities:
-    drop:
-      - ALL
-  privileged: false
-  readOnlyRootFilesystem: true
-  runAsGroup: 1069
-  runAsNonRoot: true
-  runAsUser: 1069
-  allowPrivilegeEscalation: false
-  seccompProfile:
-    type: RuntimeDefault
-
 aiven:
   projects: # Space separated list of Aiven projects with Kafka clusters available for this aivenator instance
   mainProject: # Main Aiven project for services that only support one


### PR DESCRIPTION
moved security context to values.yaml
capabilities drop need to be all caps for ALL
added seccompProfile

Error from kyverno:
> k describe rs aivenator-5fbbbb4d74
```
disallow-capabilities-strict:
  require-drop-all: 'validation failure: Containers must drop `ALL` capabilities.'
restrict-seccomp-strict:
  check-seccomp-strict: 'validation error: Use of custom Seccomp profiles is disallowed.
    The fields spec.securityContext.seccompProfile.type, spec.containers[*].securityContext.seccompProfile.type,
    spec.initContainers[*].securityContext.seccompProfile.type, and spec.ephemeralContainers[*].securityContext.seccompProfile.type
    must be set to `RuntimeDefault` or `Localhost`. Rule check-seccomp-strict[0] failed
    at path /spec/securityContext/seccompProfile/. Rule check-seccomp-strict[1] failed
```