### PR TITLE
Rewrite secret cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-K8S_VERSION := 1.19.0
+K8S_VERSION := 1.24.2
 arch        := amd64
 os          := $(shell uname -s | tr '[:upper:]' '[:lower:]')
 testbin_dir := ./.testbin/

--- a/cmd/aivenator/main.go
+++ b/cmd/aivenator/main.go
@@ -220,14 +220,13 @@ func manageCredentials(ctx context.Context, aiven *aiven.Client, logger *log.Log
 	}
 	logger.Info("Aiven Secret finalizer setup complete")
 
-	// TODO: Better naming
-	credentialsJanitor := credentials.Janitor{
+	credentialsCleaner := credentials.Cleaner{
 		Client: mgr.GetClient(),
 		Logger: logger.WithFields(log.Fields{
-			"component": "AivenApplicationJanitor",
+			"component": "SecretsCleaner",
 		}),
 	}
-	janitor := secrets.NewJanitor(credentialsJanitor, appChanges, logger.WithFields(log.Fields{"component": "SecretsJanitor"}))
+	janitor := secrets.NewJanitor(credentialsCleaner, appChanges, logger.WithFields(log.Fields{"component": "SecretsJanitor"}))
 	if err := mgr.Add(janitor); err != nil {
 		return fmt.Errorf("unable to add janitor to manager: %v", err)
 	}

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -7,9 +7,10 @@ const (
 	TeamLabel       = "team"
 	SecretTypeLabel = "type"
 
-	AivenatorProtectedAnnotation         = "aivenator.aiven.nais.io/protected"
-	AivenatorProtectedExpireAtAnnotation = "aivenator.aiven.nais.io/with-time-limit"
-	AivenatorRetryCounterAnnotation      = "aivenator.aiven.nais.io/retries"
+	AivenatorProtectedAnnotation              = "aivenator.aiven.nais.io/protected"
+	AivenatorProtectedWithTimeLimitAnnotation = "aivenator.aiven.nais.io/with-time-limit"
+	AivenatorProtectedExpiresAtAnnotation     = "aivenator.aiven.nais.io/expires-at"
+	AivenatorRetryCounterAnnotation           = "aivenator.aiven.nais.io/retries"
 
 	AivenatorSecretType = "aivenator.aiven.nais.io"
 )

--- a/controllers/controllers_test.go
+++ b/controllers/controllers_test.go
@@ -230,15 +230,6 @@ func TestControllers(t *testing.T) {
 	// Check secret created with correct data
 	secret := v1.Secret{}
 	rig.assertExists(ctx, &secret, secretKey)
-	actualOwnerReferences := secret.GetOwnerReferences()
-	assert.Equal(t, 1, len(actualOwnerReferences))
-	expectedOwnerReference := metav1.OwnerReference{
-		APIVersion: replicaSet.APIVersion,
-		Kind:       replicaSet.Kind,
-		Name:       replicaSet.Name,
-		UID:        replicaSet.UID,
-	}
-	assert.Equal(t, expectedOwnerReference, actualOwnerReferences[0])
 	actualFinalizers := secret.GetFinalizers()
 	assert.Equal(t, 1, len(actualFinalizers))
 	assert.Equal(t, constants.AivenatorFinalizer, actualFinalizers[0])

--- a/controllers/controllers_test.go
+++ b/controllers/controllers_test.go
@@ -58,6 +58,8 @@ func testBinDirectory() string {
 }
 
 func newTestRig(ctx context.Context, t *testing.T, logger *log.Logger) (*testRig, error) {
+	ctx, cancelFunc := context.WithCancel(ctx)
+
 	err := os.Setenv("KUBEBUILDER_ASSETS", testBinDirectory())
 	if err != nil {
 		return nil, fmt.Errorf("failed to set environment variable: %w", err)
@@ -79,6 +81,7 @@ func newTestRig(ctx context.Context, t *testing.T, logger *log.Logger) (*testRig
 
 	t.Cleanup(func() {
 		t.Log("Stopping Kubernetes")
+		cancelFunc()
 		if err := rig.kubernetes.Stop(); err != nil {
 			t.Errorf("failed to stop kubernetes test rig: %s", err)
 		}

--- a/controllers/controllers_test.go
+++ b/controllers/controllers_test.go
@@ -126,13 +126,13 @@ func newTestRig(ctx context.Context, t *testing.T, logger *log.Logger) (*testRig
 	}
 	rig.synchronizer = &reconciler
 
-	credentialsJanitor := credentials.Janitor{
+	credentialsCleaner := credentials.Cleaner{
 		Client: rig.manager.GetClient(),
 		Logger: logger.WithFields(log.Fields{
-			"component": "AivenApplicationJanitor",
+			"component": "SecretsCleaner",
 		}),
 	}
-	janitor := secrets.NewJanitor(credentialsJanitor, appChanges, logger)
+	janitor := secrets.NewJanitor(credentialsCleaner, appChanges, logger)
 	err = rig.manager.Add(janitor)
 	if err != nil {
 		return nil, fmt.Errorf("add janitor to manager: %w", err)

--- a/controllers/secrets/janitor.go
+++ b/controllers/secrets/janitor.go
@@ -1,0 +1,58 @@
+package secrets
+
+import (
+	"context"
+	"github.com/nais/aivenator/pkg/credentials"
+	aiven_nais_io_v1 "github.com/nais/liberator/pkg/apis/aiven.nais.io/v1"
+	log "github.com/sirupsen/logrus"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"time"
+)
+
+const (
+	cleanUpInterval = 15 * time.Minute
+)
+
+type Janitor struct {
+	client.Client
+	logger     log.FieldLogger
+	janitor    credentials.Janitor
+	appChanges <-chan aiven_nais_io_v1.AivenApplication
+}
+
+func NewJanitor(janitor credentials.Janitor, appChanges <-chan aiven_nais_io_v1.AivenApplication, logger log.FieldLogger) *Janitor {
+	return &Janitor{
+		logger:     logger,
+		janitor:    janitor,
+		appChanges: appChanges,
+	}
+}
+
+func (j *Janitor) InjectClient(c client.Client) error {
+	j.Client = c
+	return nil
+}
+
+func (j *Janitor) Start(ctx context.Context) error {
+	ticker := time.NewTicker(cleanUpInterval)
+
+	for {
+		select {
+		case <-ticker.C:
+			j.logger.Info("Running janitor for all secrets")
+			err := j.janitor.CleanUnusedSecrets(ctx)
+			if err != nil {
+				return err
+			}
+		case app := <-j.appChanges:
+			// Clean secrets for app
+			j.logger.Infof("Running janitor for secrets belonging to aivenapp %s/%s", app.GetNamespace(), app.GetName())
+			err := j.janitor.CleanUnusedSecretsForApplication(ctx, app)
+			if err != nil {
+				return err
+			}
+		case <-ctx.Done():
+			return nil
+		}
+	}
+}

--- a/controllers/secrets/janitor.go
+++ b/controllers/secrets/janitor.go
@@ -16,14 +16,14 @@ const (
 type Janitor struct {
 	client.Client
 	logger     log.FieldLogger
-	janitor    credentials.Janitor
+	cleaner    credentials.Cleaner
 	appChanges <-chan aiven_nais_io_v1.AivenApplication
 }
 
-func NewJanitor(janitor credentials.Janitor, appChanges <-chan aiven_nais_io_v1.AivenApplication, logger log.FieldLogger) *Janitor {
+func NewJanitor(cleaner credentials.Cleaner, appChanges <-chan aiven_nais_io_v1.AivenApplication, logger log.FieldLogger) *Janitor {
 	return &Janitor{
 		logger:     logger,
-		janitor:    janitor,
+		cleaner:    cleaner,
 		appChanges: appChanges,
 	}
 }
@@ -39,15 +39,15 @@ func (j *Janitor) Start(ctx context.Context) error {
 	for {
 		select {
 		case <-ticker.C:
-			j.logger.Info("Running janitor for all secrets")
-			err := j.janitor.CleanUnusedSecrets(ctx)
+			j.logger.Info("Running cleaner for all secrets")
+			err := j.cleaner.CleanUnusedSecrets(ctx)
 			if err != nil {
 				return err
 			}
 		case app := <-j.appChanges:
 			// Clean secrets for app
-			j.logger.Infof("Running janitor for secrets belonging to aivenapp %s/%s", app.GetNamespace(), app.GetName())
-			err := j.janitor.CleanUnusedSecretsForApplication(ctx, app)
+			j.logger.Infof("Running cleaner for secrets belonging to aivenapp %s/%s", app.GetNamespace(), app.GetName())
+			err := j.cleaner.CleanUnusedSecretsForApplication(ctx, app)
 			if err != nil {
 				return err
 			}

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -15,6 +15,6 @@ func HasProtected(annotations map[string]string) bool {
 }
 
 func HasTimeLimited(annotations map[string]string) bool {
-	value, found := hasAnnotation(annotations, constants.AivenatorProtectedExpireAtAnnotation)
+	value, found := hasAnnotation(annotations, constants.AivenatorProtectedWithTimeLimitAnnotation)
 	return found && value == "true"
 }

--- a/pkg/credentials/cleaner.go
+++ b/pkg/credentials/cleaner.go
@@ -280,7 +280,7 @@ func getItemList(ctx context.Context, c Client, items client.ObjectList, appName
 		return c.List(ctx, items, mLabels)
 	})
 	if err != nil {
-		return fmt.Errorf("failed to retrieve list of pods: %v", err)
+		return fmt.Errorf("failed to retrieve list of resources: %v", err)
 	}
 	return nil
 }

--- a/pkg/credentials/cleaner_test.go
+++ b/pkg/credentials/cleaner_test.go
@@ -69,8 +69,8 @@ func (suite *JanitorTestSuite) SetupTest() {
 	suite.clientBuilder.WithScheme(s)
 }
 
-func (suite *JanitorTestSuite) buildJanitor(client Client) *Janitor {
-	return &Janitor{
+func (suite *JanitorTestSuite) buildJanitor(client Client) *Cleaner {
+	return &Cleaner{
 		Client: client,
 		Logger: suite.logger,
 	}

--- a/pkg/credentials/janitor_test.go
+++ b/pkg/credentials/janitor_test.go
@@ -123,6 +123,9 @@ func (suite *JanitorTestSuite) TestUnusedSecretsFound() {
 			SecretName: CurrentlyRequestedSecret,
 		}).
 		Build()
+	application.SetLabels(map[string]string{
+		constants.AppLabel: MyAppName,
+	})
 	suite.clientBuilder.WithRuntimeObjects(
 		makePodForSecret(SecretUsedByPod),
 		&application,
@@ -183,6 +186,30 @@ func (suite *JanitorTestSuite) TestErrors() {
 					[]interface{}{fmt.Errorf("api error")},
 					nil,
 				},
+				{
+					"List",
+					[]interface{}{mock.Anything, mock.AnythingOfType("*aiven_nais_io_v1.AivenApplicationList"), mock.AnythingOfType("client.MatchingLabels")},
+					[]interface{}{nil},
+					nil,
+				},
+				{
+					"List",
+					[]interface{}{mock.Anything, mock.AnythingOfType("*v1.ReplicaSetList"), mock.AnythingOfType("client.MatchingLabels")},
+					[]interface{}{nil},
+					nil,
+				},
+				{
+					"List",
+					[]interface{}{mock.Anything, mock.AnythingOfType("*v1.CronJobList"), mock.AnythingOfType("client.MatchingLabels")},
+					[]interface{}{nil},
+					nil,
+				},
+				{
+					"List",
+					[]interface{}{mock.Anything, mock.AnythingOfType("*v1.JobList"), mock.AnythingOfType("client.MatchingLabels")},
+					[]interface{}{nil},
+					nil,
+				},
 			},
 			expected: fmt.Errorf("failed to retrieve list of pods: api error"),
 		},
@@ -207,25 +234,25 @@ func (suite *JanitorTestSuite) TestErrors() {
 				},
 				{
 					"List",
-					[]interface{}{mock.Anything, mock.AnythingOfType("*aiven_nais_io_v1.AivenApplicationList")},
+					[]interface{}{mock.Anything, mock.AnythingOfType("*aiven_nais_io_v1.AivenApplicationList"), mock.AnythingOfType("client.MatchingLabels")},
 					[]interface{}{nil},
 					nil,
 				},
 				{
 					"List",
-					[]interface{}{mock.Anything, mock.AnythingOfType("*v1.ReplicaSetList")},
+					[]interface{}{mock.Anything, mock.AnythingOfType("*v1.ReplicaSetList"), mock.AnythingOfType("client.MatchingLabels")},
 					[]interface{}{nil},
 					nil,
 				},
 				{
 					"List",
-					[]interface{}{mock.Anything, mock.AnythingOfType("*v1.CronJobList")},
+					[]interface{}{mock.Anything, mock.AnythingOfType("*v1.CronJobList"), mock.AnythingOfType("client.MatchingLabels")},
 					[]interface{}{nil},
 					nil,
 				},
 				{
 					"List",
-					[]interface{}{mock.Anything, mock.AnythingOfType("*v1.JobList")},
+					[]interface{}{mock.Anything, mock.AnythingOfType("*v1.JobList"), mock.AnythingOfType("client.MatchingLabels")},
 					[]interface{}{nil},
 					nil,
 				},
@@ -262,25 +289,25 @@ func (suite *JanitorTestSuite) TestErrors() {
 				},
 				{
 					"List",
-					[]interface{}{mock.Anything, mock.AnythingOfType("*aiven_nais_io_v1.AivenApplicationList")},
+					[]interface{}{mock.Anything, mock.AnythingOfType("*aiven_nais_io_v1.AivenApplicationList"), mock.AnythingOfType("client.MatchingLabels")},
 					[]interface{}{nil},
 					nil,
 				},
 				{
 					"List",
-					[]interface{}{mock.Anything, mock.AnythingOfType("*v1.ReplicaSetList")},
+					[]interface{}{mock.Anything, mock.AnythingOfType("*v1.ReplicaSetList"), mock.AnythingOfType("client.MatchingLabels")},
 					[]interface{}{nil},
 					nil,
 				},
 				{
 					"List",
-					[]interface{}{mock.Anything, mock.AnythingOfType("*v1.CronJobList")},
+					[]interface{}{mock.Anything, mock.AnythingOfType("*v1.CronJobList"), mock.AnythingOfType("client.MatchingLabels")},
 					[]interface{}{nil},
 					nil,
 				},
 				{
 					"List",
-					[]interface{}{mock.Anything, mock.AnythingOfType("*v1.JobList")},
+					[]interface{}{mock.Anything, mock.AnythingOfType("*v1.JobList"), mock.AnythingOfType("client.MatchingLabels")},
 					[]interface{}{nil},
 					nil,
 				},

--- a/pkg/credentials/manager.go
+++ b/pkg/credentials/manager.go
@@ -6,7 +6,6 @@ import (
 	"github.com/nais/aivenator/pkg/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 	"reflect"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"time"
 
 	"github.com/aiven/aiven-go-client"
@@ -19,7 +18,7 @@ import (
 )
 
 type Handler interface {
-	Apply(application *aiven_nais_io_v1.AivenApplication, objects []client.Object, secret *v1.Secret, logger *log.Entry) error
+	Apply(application *aiven_nais_io_v1.AivenApplication, secret *v1.Secret, logger *log.Entry) error
 	Cleanup(secret *v1.Secret, logger *log.Entry) error
 }
 
@@ -37,10 +36,10 @@ func NewManager(ctx context.Context, aiven *aiven.Client, kafkaProjects []string
 	}
 }
 
-func (c Manager) CreateSecret(application *aiven_nais_io_v1.AivenApplication, objects []client.Object, secret *v1.Secret, logger *log.Entry) (*v1.Secret, error) {
+func (c Manager) CreateSecret(application *aiven_nais_io_v1.AivenApplication, secret *v1.Secret, logger *log.Entry) (*v1.Secret, error) {
 	for _, handler := range c.handlers {
 		processingStart := time.Now()
-		err := handler.Apply(application, objects, secret, logger)
+		err := handler.Apply(application, secret, logger)
 		if err != nil {
 			cleanupError := c.Cleanup(secret, logger)
 			if cleanupError != nil {

--- a/pkg/credentials/manager_test.go
+++ b/pkg/credentials/manager_test.go
@@ -18,12 +18,11 @@ func TestManager_Apply(t *testing.T) {
 	mockHandler.
 		On("Apply",
 			mock.AnythingOfType("*aiven_nais_io_v1.AivenApplication"),
-			mock.Anything,
 			mock.AnythingOfType("*v1.Secret"),
 			mock.Anything).
 		Return(nil).
 		Run(func(args mock.Arguments) {
-			secret := args.Get(2).(*corev1.Secret)
+			secret := args.Get(1).(*corev1.Secret)
 			secret.ObjectMeta.Annotations = make(map[string]string, len(expectedAnnotations))
 			for key, value := range expectedAnnotations {
 				secret.ObjectMeta.Annotations[key] = value
@@ -34,7 +33,7 @@ func TestManager_Apply(t *testing.T) {
 
 	// when
 	secret := &corev1.Secret{}
-	secret, err := manager.CreateSecret(&application, nil, secret, nil)
+	secret, err := manager.CreateSecret(&application, secret, nil)
 
 	// then
 	assert.NoError(t, err)
@@ -50,12 +49,11 @@ func TestManager_ApplyFailed(t *testing.T) {
 	mockHandler.
 		On("Apply",
 			mock.AnythingOfType("*aiven_nais_io_v1.AivenApplication"),
-			mock.Anything,
 			mock.AnythingOfType("*v1.Secret"),
 			mock.Anything).
 		Return(nil).
 		Run(func(args mock.Arguments) {
-			secret := args.Get(2).(*corev1.Secret)
+			secret := args.Get(1).(*corev1.Secret)
 			secret.ObjectMeta.Annotations = make(map[string]string, len(expectedAnnotations))
 			for key, value := range expectedAnnotations {
 				secret.ObjectMeta.Annotations[key] = value
@@ -68,7 +66,6 @@ func TestManager_ApplyFailed(t *testing.T) {
 	failingHandler.
 		On("Apply",
 			mock.AnythingOfType("*aiven_nais_io_v1.AivenApplication"),
-			mock.Anything,
 			mock.AnythingOfType("*v1.Secret"),
 			mock.Anything).
 		Return(handlerError)
@@ -80,7 +77,7 @@ func TestManager_ApplyFailed(t *testing.T) {
 
 	// when
 	secret := &corev1.Secret{}
-	_, err := manager.CreateSecret(&application, nil, secret, nil)
+	_, err := manager.CreateSecret(&application, secret, nil)
 
 	// then
 	assert.Error(t, err)

--- a/pkg/handlers/kafka/kafka.go
+++ b/pkg/handlers/kafka/kafka.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"hash/crc32"
 	"os"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"time"
 
 	"github.com/aiven/aiven-go-client"
@@ -71,7 +70,7 @@ type KafkaHandler struct {
 	projects     []string
 }
 
-func (h KafkaHandler) Apply(application *aiven_nais_io_v1.AivenApplication, _ []client.Object, secret *v1.Secret, logger *log.Entry) error {
+func (h KafkaHandler) Apply(application *aiven_nais_io_v1.AivenApplication, secret *v1.Secret, logger *log.Entry) error {
 	logger = logger.WithFields(log.Fields{"handler": "kafka"})
 	if application.Spec.Kafka == nil {
 		return nil

--- a/pkg/handlers/kafka/kafka_test.go
+++ b/pkg/handlers/kafka/kafka_test.go
@@ -167,7 +167,7 @@ func (suite *KafkaHandlerTestSuite) TestCleanupServiceUserAlreadyGone() {
 func (suite *KafkaHandlerTestSuite) TestNoKafka() {
 	application := suite.applicationBuilder.Build()
 	secret := &v1.Secret{}
-	err := suite.kafkaHandler.Apply(&application, nil, secret, suite.logger)
+	err := suite.kafkaHandler.Apply(&application, secret, suite.logger)
 
 	suite.NoError(err)
 	suite.Equal(&v1.Secret{}, secret)
@@ -183,7 +183,7 @@ func (suite *KafkaHandlerTestSuite) TestKafkaOk() {
 		}).
 		Build()
 	secret := &v1.Secret{}
-	err := suite.kafkaHandler.Apply(&application, nil, secret, suite.logger)
+	err := suite.kafkaHandler.Apply(&application, secret, suite.logger)
 
 	suite.NoError(err)
 	expected := &v1.Secret{
@@ -224,7 +224,7 @@ func (suite *KafkaHandlerTestSuite) TestSecretExists() {
 	}
 	suite.addDefaultMocks(enabled(ServicesGetAddresses, ProjectGetCA, GeneratorMakeCredStores, ServiceUsersGet))
 
-	err := suite.kafkaHandler.Apply(&application, nil, secret, suite.logger)
+	err := suite.kafkaHandler.Apply(&application, secret, suite.logger)
 
 	suite.NoError(err)
 	suite.Equal(secret.GetAnnotations()[ServiceUserAnnotation], serviceUserName)
@@ -247,7 +247,7 @@ func (suite *KafkaHandlerTestSuite) TestServiceGetFailed() {
 			Status:   500,
 		})
 
-	err := suite.kafkaHandler.Apply(&application, nil, secret, suite.logger)
+	err := suite.kafkaHandler.Apply(&application, secret, suite.logger)
 
 	suite.Error(err)
 	suite.NotNil(application.Status.GetConditionOfType(aiven_nais_io_v1.AivenApplicationAivenFailure))
@@ -270,7 +270,7 @@ func (suite *KafkaHandlerTestSuite) TestProjectGetCAFailed() {
 			Status:   500,
 		})
 
-	err := suite.kafkaHandler.Apply(&application, nil, secret, suite.logger)
+	err := suite.kafkaHandler.Apply(&application, secret, suite.logger)
 
 	suite.Error(err)
 	suite.NotNil(application.Status.GetConditionOfType(aiven_nais_io_v1.AivenApplicationAivenFailure))
@@ -293,7 +293,7 @@ func (suite *KafkaHandlerTestSuite) TestServiceUsersCreateFailed() {
 			Status:   500,
 		})
 
-	err := suite.kafkaHandler.Apply(&application, nil, secret, suite.logger)
+	err := suite.kafkaHandler.Apply(&application, secret, suite.logger)
 
 	suite.Error(err)
 	suite.NotNil(application.Status.GetConditionOfType(aiven_nais_io_v1.AivenApplicationAivenFailure))
@@ -316,7 +316,7 @@ func (suite *KafkaHandlerTestSuite) TestServiceUserNotFound() {
 	}
 	suite.addDefaultMocks(enabled(ServicesGetAddresses, ProjectGetCA, ServiceUsersCreate, GeneratorMakeCredStores, ServiceUsersGetNotFound))
 
-	err := suite.kafkaHandler.Apply(&application, nil, secret, suite.logger)
+	err := suite.kafkaHandler.Apply(&application, secret, suite.logger)
 
 	suite.NoError(err)
 	expected := &v1.Secret{
@@ -352,7 +352,7 @@ func (suite *KafkaHandlerTestSuite) TestServiceUserCollision() {
 			Username: serviceUserName,
 		}, nil)
 
-	err := suite.kafkaHandler.Apply(&application, nil, secret, suite.logger)
+	err := suite.kafkaHandler.Apply(&application, secret, suite.logger)
 
 	suite.mockServiceUsers.AssertNotCalled(suite.T(), "Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 	suite.NoError(err)
@@ -380,7 +380,7 @@ func (suite *KafkaHandlerTestSuite) TestInvalidPool() {
 		}).
 		Build()
 	secret := &v1.Secret{}
-	err := suite.kafkaHandler.Apply(&application, nil, secret, suite.logger)
+	err := suite.kafkaHandler.Apply(&application, secret, suite.logger)
 
 	suite.Error(err)
 	suite.True(errors.Is(err, utils.UnrecoverableError))
@@ -400,7 +400,7 @@ func (suite *KafkaHandlerTestSuite) TestGeneratorMakeCredStoresFailed() {
 	suite.mockGenerator.On("MakeCredStores", mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, fmt.Errorf("local-fail"))
 
-	err := suite.kafkaHandler.Apply(&application, nil, secret, suite.logger)
+	err := suite.kafkaHandler.Apply(&application, secret, suite.logger)
 
 	suite.Error(err)
 	suite.NotNil(application.Status.GetConditionOfType(aiven_nais_io_v1.AivenApplicationLocalFailure))

--- a/pkg/handlers/opensearch/opensearch.go
+++ b/pkg/handlers/opensearch/opensearch.go
@@ -3,8 +3,6 @@ package opensearch
 import (
 	"context"
 	"fmt"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	"github.com/aiven/aiven-go-client"
 	"github.com/nais/aivenator/pkg/aiven/project"
 	"github.com/nais/aivenator/pkg/aiven/service"
@@ -44,7 +42,7 @@ type OpenSearchHandler struct {
 	projectName string
 }
 
-func (h OpenSearchHandler) Apply(application *aiven_nais_io_v1.AivenApplication, _ []client.Object, secret *v1.Secret, logger *log.Entry) error {
+func (h OpenSearchHandler) Apply(application *aiven_nais_io_v1.AivenApplication, secret *v1.Secret, logger *log.Entry) error {
 	logger = logger.WithFields(log.Fields{"handler": "opensearch"})
 	spec := application.Spec.OpenSearch
 	if spec == nil {

--- a/pkg/handlers/opensearch/opensearch_test.go
+++ b/pkg/handlers/opensearch/opensearch_test.go
@@ -87,7 +87,7 @@ func (suite *OpenSearchHandlerTestSuite) TestNoOpenSearch() {
 	suite.addDefaultMocks(enabled(ServicesGetAddresses))
 	application := suite.applicationBuilder.Build()
 	secret := &v1.Secret{}
-	err := suite.opensearchHandler.Apply(&application, nil, secret, suite.logger)
+	err := suite.opensearchHandler.Apply(&application, secret, suite.logger)
 
 	suite.NoError(err)
 	suite.Equal(&v1.Secret{}, secret)
@@ -104,7 +104,7 @@ func (suite *OpenSearchHandlerTestSuite) TestOpenSearchOk() {
 		}).
 		Build()
 	secret := &v1.Secret{}
-	err := suite.opensearchHandler.Apply(&application, nil, secret, suite.logger)
+	err := suite.opensearchHandler.Apply(&application, secret, suite.logger)
 
 	suite.NoError(err)
 	expected := &v1.Secret{
@@ -142,7 +142,7 @@ func (suite *OpenSearchHandlerTestSuite) TestServiceGetFailed() {
 			Status:   500,
 		})
 
-	err := suite.opensearchHandler.Apply(&application, nil, secret, suite.logger)
+	err := suite.opensearchHandler.Apply(&application, secret, suite.logger)
 
 	suite.Error(err)
 	suite.NotNil(application.Status.GetConditionOfType(aiven_nais_io_v1.AivenApplicationAivenFailure))
@@ -166,7 +166,7 @@ func (suite *OpenSearchHandlerTestSuite) TestServiceUsersGetFailed() {
 			Status:   500,
 		})
 
-	err := suite.opensearchHandler.Apply(&application, nil, secret, suite.logger)
+	err := suite.opensearchHandler.Apply(&application, secret, suite.logger)
 
 	suite.Error(err)
 	suite.NotNil(application.Status.GetConditionOfType(aiven_nais_io_v1.AivenApplicationAivenFailure))
@@ -212,7 +212,7 @@ func (suite *OpenSearchHandlerTestSuite) TestCorrectServiceUserSelected() {
 				}).
 				Build()
 			secret := &v1.Secret{}
-			err := suite.opensearchHandler.Apply(&application, nil, secret, suite.logger)
+			err := suite.opensearchHandler.Apply(&application, secret, suite.logger)
 
 			suite.NoError(err)
 			suite.Equal(t.username, secret.StringData[OpenSearchUser])

--- a/pkg/handlers/secret/secret.go
+++ b/pkg/handlers/secret/secret.go
@@ -62,7 +62,8 @@ func createAnnotations(application *aiven_nais_io_v1.AivenApplication) map[strin
 	}
 
 	if application.Spec.Protected && application.Spec.ExpiresAt != nil {
-		annotations[constants.AivenatorProtectedExpireAtAnnotation] = strconv.FormatBool(true)
+		annotations[constants.AivenatorProtectedWithTimeLimitAnnotation] = strconv.FormatBool(true)
+		annotations[constants.AivenatorProtectedExpiresAtAnnotation] = application.Spec.ExpiresAt.Format(time.RFC3339)
 	}
 	return annotations
 }

--- a/pkg/handlers/secret/secret_test.go
+++ b/pkg/handlers/secret/secret_test.go
@@ -3,7 +3,6 @@ package secret
 import (
 	"errors"
 	"github.com/nais/aivenator/pkg/utils"
-	v1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"testing"
@@ -18,12 +17,10 @@ import (
 )
 
 const (
-	namespace           = "ns"
-	applicationName     = "app"
-	replicaSetName      = "my-replicaset"
-	otherReplicaSetName = "other-replicaset"
-	secretName          = "my-secret"
-	correlationId       = "correlation-id"
+	namespace       = "ns"
+	applicationName = "app"
+	secretName      = "my-secret"
+	correlationId   = "correlation-id"
 )
 
 func TestHandler_Apply(t *testing.T) {
@@ -37,26 +34,6 @@ func TestHandler_Apply(t *testing.T) {
 	exampleAivenApplication := aiven_nais_io_v1.NewAivenApplicationBuilder(applicationName, namespace).
 		WithSpec(aiven_nais_io_v1.AivenApplicationSpec{SecretName: secretName}).
 		Build()
-	exampleReplicaSet := &v1.ReplicaSet{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "ReplicaSet",
-			APIVersion: "apps/v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      replicaSetName,
-			Namespace: namespace,
-		},
-	}
-	otherReplicaSet := &v1.ReplicaSet{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "ReplicaSet",
-			APIVersion: "apps/v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      otherReplicaSetName,
-			Namespace: namespace,
-		},
-	}
 	tests := []struct {
 		name string
 		args args
@@ -91,29 +68,6 @@ func TestHandler_Apply(t *testing.T) {
 			},
 		},
 		{
-			name: "ApplicationOwnerReference",
-			args: args{
-				application: exampleAivenApplication,
-				objects:     nil,
-				secret:      corev1.Secret{},
-				assert: func(t *testing.T, a args) {
-					assert.Contains(t, a.secret.OwnerReferences, a.application.GetOwnerReference(), "AivenApplication ownerReference missing")
-				},
-			},
-		},
-		{
-			name: "ReplicaSetOwnerReference",
-			args: args{
-				application: exampleAivenApplication,
-				objects:     []client.Object{exampleReplicaSet},
-				secret:      corev1.Secret{},
-				assert: func(t *testing.T, a args) {
-					assert.Contains(t, a.secret.OwnerReferences, makeOwnerReference(exampleReplicaSet), "ReplicaSet ownerReference missing")
-					assert.NotContains(t, a.secret.OwnerReferences, a.application.GetOwnerReference(), "AivenApplication ownerReference present")
-				},
-			},
-		},
-		{
 			name: "PreexistingSecret",
 			args: args{
 				application: exampleAivenApplication,
@@ -133,80 +87,9 @@ func TestHandler_Apply(t *testing.T) {
 					assert.Contains(t, a.secret.Annotations, "pre-existing-annotation", "existing annotation missing")
 					assert.Contains(t, a.secret.Annotations, nais_io_v1.DeploymentCorrelationIDAnnotation, "new annotation missing")
 					assert.Contains(t, a.secret.Finalizers, "pre-existing-finalizer", "existing finalizer missing")
-
 					assert.Contains(t, a.secret.OwnerReferences, metav1.OwnerReference{Name: "pre-existing-owner-reference"}, "pre-existing ownerReference missing")
-					assert.Contains(t, a.secret.OwnerReferences, a.application.GetOwnerReference(), "AivenApplication ownerReference missing")
-				},
-			},
-		},
-		{
-			name: "ReprocessingSecret",
-			args: args{
-				application: exampleAivenApplication,
-				secret: corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:            secretName,
-						Namespace:       namespace,
-						Labels:          map[string]string{"pre-existing-label": "pre-existing-label"},
-						Annotations:     map[string]string{"pre-existing-annotation": "pre-existing-annotation"},
-						OwnerReferences: []metav1.OwnerReference{exampleAivenApplication.GetOwnerReference()},
-						Finalizers:      []string{"pre-existing-finalizer"},
-					},
-				},
-				assert: func(t *testing.T, a args) {
-					assert.Contains(t, a.secret.Labels, "pre-existing-label", "existing label missing")
-					assert.Contains(t, a.secret.Labels, constants.AppLabel, "new label missing")
-					assert.Contains(t, a.secret.Annotations, "pre-existing-annotation", "existing annotation missing")
-					assert.Contains(t, a.secret.Annotations, nais_io_v1.DeploymentCorrelationIDAnnotation, "new annotation missing")
-					assert.Contains(t, a.secret.Finalizers, "pre-existing-finalizer", "existing finalizer missing")
 
-					assert.Contains(t, a.secret.OwnerReferences, a.application.GetOwnerReference(), "new ownerReference missing")
-					assert.Len(t, a.secret.OwnerReferences, 1, "duplicate ownerReferences")
-				},
-			},
-		},
-		{
-			name: "ReplaceAivenApplicationOwnerWithReplicaSet",
-			args: args{
-				application: exampleAivenApplication,
-				objects:     []client.Object{exampleReplicaSet},
-				secret: corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:            secretName,
-						Namespace:       namespace,
-						Labels:          map[string]string{"pre-existing-label": "pre-existing-label"},
-						Annotations:     map[string]string{"pre-existing-annotation": "pre-existing-annotation"},
-						OwnerReferences: []metav1.OwnerReference{exampleAivenApplication.GetOwnerReference()},
-						Finalizers:      []string{"pre-existing-finalizer"},
-					},
-				},
-				assert: func(t *testing.T, a args) {
-					assert.Contains(t, a.secret.OwnerReferences, makeOwnerReference(exampleReplicaSet), "ReplicaSet ownerReference missing")
-					assert.NotContains(t, a.secret.OwnerReferences, a.application.GetOwnerReference(), "AivenApplication ownerReference present")
-					assert.Len(t, a.secret.OwnerReferences, 1, "multiple ownerReferences")
-				},
-			},
-		},
-		{
-			name: "AddSecondReplicaSetOwnerWithReplicaSet",
-			args: args{
-				application: exampleAivenApplication,
-				objects:     []client.Object{exampleReplicaSet},
-				secret: corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:            secretName,
-						Namespace:       namespace,
-						Labels:          map[string]string{"pre-existing-label": "pre-existing-label"},
-						Annotations:     map[string]string{"pre-existing-annotation": "pre-existing-annotation"},
-						OwnerReferences: []metav1.OwnerReference{makeOwnerReference(otherReplicaSet)},
-						Finalizers:      []string{"pre-existing-finalizer"},
-					},
-				},
-				assert: func(t *testing.T, a args) {
-					assert.Contains(t, a.secret.OwnerReferences, makeOwnerReference(exampleReplicaSet), "Example ReplicaSet ownerReference missing")
-					assert.Contains(t, a.secret.OwnerReferences, makeOwnerReference(otherReplicaSet), "Other ReplicaSet ownerReference missing")
-					assert.NotContains(t, a.secret.OwnerReferences, a.application.GetOwnerReference(), "AivenApplication ownerReference present")
-					assert.Len(t, a.secret.OwnerReferences, 2, "incorrect number of ownerReferences")
+					assert.Len(t, a.secret.OwnerReferences, 1, "additional ownerReferences set")
 				},
 			},
 		},
@@ -262,7 +145,7 @@ func TestHandler_Apply(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := Handler{}
-			err := s.Apply(&tt.args.application, tt.args.objects, &tt.args.secret, nil)
+			err := s.Apply(&tt.args.application, &tt.args.secret, nil)
 
 			if tt.args.assertUnrecoverable {
 				assert.Error(t, err)
@@ -275,14 +158,5 @@ func TestHandler_Apply(t *testing.T) {
 				tt.args.assert(t, tt.args)
 			}
 		})
-	}
-}
-
-func makeOwnerReference(in *v1.ReplicaSet) metav1.OwnerReference {
-	return metav1.OwnerReference{
-		APIVersion: in.APIVersion,
-		Kind:       in.Kind,
-		Name:       in.Name,
-		UID:        in.UID,
 	}
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -116,7 +116,7 @@ var (
 		Name:      "secrets_managed",
 		Namespace: Namespace,
 		Help:      "number of secrets managed",
-	}, []string{LabelNamespace, LabelSecretState})
+	}, []string{LabelSecretState})
 )
 
 func ObserveAivenLatency(operation, pool string, fun func() error) error {

--- a/pkg/mocks/handler.go
+++ b/pkg/mocks/handler.go
@@ -4,7 +4,6 @@ package mocks
 
 import (
 	aiven_nais_io_v1 "github.com/nais/liberator/pkg/apis/aiven.nais.io/v1"
-	client "sigs.k8s.io/controller-runtime/pkg/client"
 
 	logrus "github.com/sirupsen/logrus"
 
@@ -18,13 +17,13 @@ type Handler struct {
 	mock.Mock
 }
 
-// Apply provides a mock function with given fields: application, objects, secret, logger
-func (_m *Handler) Apply(application *aiven_nais_io_v1.AivenApplication, objects []client.Object, secret *v1.Secret, logger *logrus.Entry) error {
-	ret := _m.Called(application, objects, secret, logger)
+// Apply provides a mock function with given fields: application, secret, logger
+func (_m *Handler) Apply(application *aiven_nais_io_v1.AivenApplication, secret *v1.Secret, logger *logrus.Entry) error {
+	ret := _m.Called(application, secret, logger)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(*aiven_nais_io_v1.AivenApplication, []client.Object, *v1.Secret, *logrus.Entry) error); ok {
-		r0 = rf(application, objects, secret, logger)
+	if rf, ok := ret.Get(0).(func(*aiven_nais_io_v1.AivenApplication, *v1.Secret, *logrus.Entry) error); ok {
+		r0 = rf(application, secret, logger)
 	} else {
 		r0 = ret.Error(0)
 	}


### PR DESCRIPTION
This moves away from trying to track users of a secret by finding and setting ownerReferences on the secret.
Instead we poll the cluster on an interval and look to see if anyone is currently using a secret and if not, we delete it. We will also check secrets belonging to an application when it changes.
This makes the reconciler simpler (as it doesn't need to figure out if it needs to requeue to find new users), and the cleanup is simpler to understand.
The downside is that there is no immediate effect when deleting old replicasets, as deletion of service users will happen when the cleanup happens (interval set to 15 minutes).

This will make it possible to implement the changes in #66 where multiple deployments share a secret.