### PR TITLE
fix(redis): correct key format for secret annotation

### DIFF
--- a/pkg/handlers/influxdb/influxdb_test.go
+++ b/pkg/handlers/influxdb/influxdb_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	aivenator_mocks "github.com/nais/aivenator/pkg/mocks"
 	"github.com/stretchr/testify/mock"
+	"k8s.io/apimachinery/pkg/api/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"testing"
 	"time"
 
@@ -163,6 +165,7 @@ var _ = Describe("influxdb.Handler", func() {
 			err := influxdbHandler.Apply(ctx, &application, &secret, logger)
 
 			Expect(err).To(Succeed())
+			Expect(validation.ValidateAnnotations(secret.GetAnnotations(), field.NewPath("metadata.annotations"))).To(BeEmpty())
 			Expect(secret.GetAnnotations()).To(HaveKeyWithValue(ProjectAnnotation, projectName))
 			Expect(secret.GetAnnotations()).To(HaveKeyWithValue(serviceUserAnnotationKey, serviceUserName))
 			Expect(secret.StringData).To(HaveKeyWithValue(usernameKey, serviceUserName))

--- a/pkg/handlers/kafka/kafka_test.go
+++ b/pkg/handlers/kafka/kafka_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"k8s.io/apimachinery/pkg/api/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"testing"
 	"time"
 
@@ -236,6 +238,7 @@ func (suite *KafkaHandlerTestSuite) TestSecretExists() {
 	err := suite.kafkaHandler.Apply(suite.ctx, &application, secret, suite.logger)
 
 	suite.NoError(err)
+	suite.Empty(validation.ValidateAnnotations(secret.GetAnnotations(), field.NewPath("metadata.annotations")))
 	suite.Equal(secret.GetAnnotations()[ServiceUserAnnotation], serviceUserName)
 }
 

--- a/pkg/handlers/redis/redis.go
+++ b/pkg/handlers/redis/redis.go
@@ -81,7 +81,7 @@ func (h RedisHandler) Apply(ctx context.Context, application *aiven_nais_io_v1.A
 			}
 		}
 
-		serviceUserAnnotationKey := fmt.Sprintf("%s.%s", keyName(spec.Instance), ServiceUserAnnotation)
+		serviceUserAnnotationKey := fmt.Sprintf("%s.%s", keyName(spec.Instance, "-"), ServiceUserAnnotation)
 
 		secret.SetAnnotations(utils.MergeStringMap(secret.GetAnnotations(), map[string]string{
 			serviceUserAnnotationKey: aivenUser.Username,
@@ -100,12 +100,12 @@ func (h RedisHandler) Apply(ctx context.Context, application *aiven_nais_io_v1.A
 	return nil
 }
 
-func keyName(instanceName string) string {
-	return namePattern.ReplaceAllString(instanceName, "_")
+func keyName(instanceName, replacement string) string {
+	return namePattern.ReplaceAllString(instanceName, replacement)
 }
 
 func envVarName(instanceName string) string {
-	return strings.ToUpper(keyName(instanceName))
+	return strings.ToUpper(keyName(instanceName, "_"))
 }
 
 func getRedisACLCategories(access string) []string {

--- a/pkg/handlers/redis/redis_test.go
+++ b/pkg/handlers/redis/redis_test.go
@@ -3,6 +3,8 @@ package redis
 import (
 	"context"
 	aivenator_mocks "github.com/nais/aivenator/pkg/mocks"
+	"k8s.io/apimachinery/pkg/api/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"testing"
 	"time"
 
@@ -42,7 +44,7 @@ var testInstances = []testData{
 		serviceURI:               "rediss://my-instance1.example.com:23456",
 		access:                   "read",
 		username:                 "test-app-r",
-		serviceUserAnnotationKey: "my_instance1.redis.aiven.nais.io/serviceUser",
+		serviceUserAnnotationKey: "my-instance1.redis.aiven.nais.io/serviceUser",
 		usernameKey:              "REDIS_USERNAME_MY_INSTANCE1",
 		passwordKey:              "REDIS_PASSWORD_MY_INSTANCE1",
 		uriKey:                   "REDIS_URI_MY_INSTANCE1",
@@ -53,7 +55,7 @@ var testInstances = []testData{
 		serviceURI:               "rediss://session-store.example.com:23456",
 		access:                   "readwrite",
 		username:                 "test-app-rw",
-		serviceUserAnnotationKey: "session_store.redis.aiven.nais.io/serviceUser",
+		serviceUserAnnotationKey: "session-store.redis.aiven.nais.io/serviceUser",
 		usernameKey:              "REDIS_USERNAME_SESSION_STORE",
 		passwordKey:              "REDIS_PASSWORD_SESSION_STORE",
 		uriKey:                   "REDIS_URI_SESSION_STORE",
@@ -192,6 +194,7 @@ var _ = Describe("redis.Handler", func() {
 		assertHappy := func(secret *v1.Secret, err error) {
 			GinkgoHelper()
 			Expect(err).To(Succeed())
+			Expect(validation.ValidateAnnotations(secret.GetAnnotations(), field.NewPath("metadata.annotations"))).To(BeEmpty())
 			Expect(secret.GetAnnotations()).To(HaveKeyWithValue(ProjectAnnotation, projectName))
 			Expect(secret.GetAnnotations()).To(HaveKeyWithValue(data.serviceUserAnnotationKey, data.username))
 			Expect(secret.StringData).To(HaveKeyWithValue(data.usernameKey, data.username))
@@ -261,6 +264,7 @@ var _ = Describe("redis.Handler", func() {
 		assertHappy := func(secret *v1.Secret, data testData, err error) {
 			GinkgoHelper()
 			Expect(err).To(Succeed())
+			Expect(validation.ValidateAnnotations(secret.GetAnnotations(), field.NewPath("metadata.annotations"))).To(BeEmpty())
 			Expect(secret.GetAnnotations()).To(HaveKeyWithValue(ProjectAnnotation, projectName))
 			Expect(secret.GetAnnotations()).To(HaveKeyWithValue(data.serviceUserAnnotationKey, data.username))
 			Expect(secret.StringData).To(HaveKeyWithValue(data.usernameKey, data.username))

--- a/pkg/handlers/secret/secret_test.go
+++ b/pkg/handlers/secret/secret_test.go
@@ -12,7 +12,9 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/mock"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"testing"
 	"time"
 )
@@ -85,6 +87,7 @@ var _ = Describe("secret.Handler", func() {
 					Build(),
 				secret: corev1.Secret{},
 				assert: func(a args) {
+					Expect(validation.ValidateAnnotations(a.secret.GetAnnotations(), field.NewPath("metadata.annotations"))).To(BeEmpty())
 					Expect(a.secret.GetAnnotations()[nais_io_v1.DeploymentCorrelationIDAnnotation]).To(Equal(correlationId))
 					Expect(a.secret.GetName()).To(Equal(a.application.Spec.SecretName))
 				},
@@ -121,6 +124,7 @@ var _ = Describe("secret.Handler", func() {
 					Build(),
 				secret: corev1.Secret{},
 				assert: func(a args) {
+					Expect(validation.ValidateAnnotations(a.secret.GetAnnotations(), field.NewPath("metadata.annotations"))).To(BeEmpty())
 					Expect(a.secret.GetAnnotations()[constants.AivenatorProtectedAnnotation]).To(Equal("true"))
 				},
 			}),


### PR DESCRIPTION
Also adds test assertions for validating the annotations using k8s apimachinery.