### PR TITLE
Allow all @read/@write commands even if they are dangerous.

### DIFF
--- a/pkg/handlers/redis/redis.go
+++ b/pkg/handlers/redis/redis.go
@@ -113,15 +113,14 @@ func getRedisACLCategories(access string) []string {
 	categories = append(categories, "-@all", "+@connection", "+@scripting", "+@pubsub", "+@transaction")
 	switch access {
 	case "admin":
-		categories = append(categories, "+@admin", "+@write", "+@read")
+		categories = append(categories, "+@admin", "-@dangerous", "+@write", "+@read")
 	case "readwrite":
-		categories = append(categories, "+@write", "+@read")
+		categories = append(categories, "-@dangerous", "+@write", "+@read")
 	case "write":
-		categories = append(categories, "+@write")
+		categories = append(categories, "-@dangerous", "+@write")
 	default:
-		categories = append(categories, "+@read")
+		categories = append(categories, "-@dangerous", "+@read")
 	}
-	categories = append(categories, "-@dangerous")
 	return categories
 }
 


### PR DESCRIPTION
Of the @dangerous commands, we are mostly concerned with the admin type commands (slave, replicas, shutdown etc.) and not the commands that "change lots" (flushdb for instance).

This way we give admin, remove all the dangerous commands, and make sure to give relevant read and write commands even if they were dangerous.