### PR TITLE
ci: bump nais/fasit-deploy to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,8 +88,8 @@ jobs:
             helm push "$chart" oci://${{ env.GOOGLE_REGISTRY }}/nais-io/nais/feature
           done
 
-  rollout:
-    name: Rollout
+  deploy:
+    name: Deploy
     if: github.actor != 'dependabot[bot]' && github.ref == 'refs/heads/main'
     needs:
       - build
@@ -98,7 +98,14 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: nais/fasit-deploy@v2 # ratchet:exclude
+      - uses: nais/fasit-deploy@v4 # ratchet:exclude
         with:
           chart: oci://${{ env.GOOGLE_REGISTRY }}/nais-io/nais/feature/aivenator
           version: ${{ needs.build.outputs.version }}
+          targets: |
+            [
+              { "target": { "kind": "tenant", "tenant": "ci-nais" }, "wait": true },
+              { "target": { "kind": "onprem", "tenant": "ci-nais" }, "wait": true },
+              { "target": { "kind": "tenant" } },
+              { "target": { "kind": "onprem" } }
+            ]


### PR DESCRIPTION
Migrate from `nais/fasit-deploy@v2` (rollouts) to `@v4` (deployments).

- Bump action to floating `@v4` (preserving existing `ratchet:exclude`).
- Add explicit `targets:` list with ci-first `wait: true` per kind, then broad fanout. `Feature.yaml` declares `environmentKinds: [tenant, onprem, legacy]`; `legacy` is dropped (not a real env-kind in Fasit).
- Rename `rollout` job → `deploy` to match the deployment concept.