### PR TITLE
refactor: use tags enforced by mutilators mutating webhook to ascertain ownership

### DIFF
--- a/pkg/services/opensearch/opensearch.go
+++ b/pkg/services/opensearch/opensearch.go
@@ -8,11 +8,11 @@ import (
 
 	"github.com/aiven/aiven-go-client/v2"
 	"github.com/nais/aivenator/constants"
-	aiven_io_v1alpha1 "github.com/nais/liberator/pkg/apis/aiven.io/v1alpha1"
 	"github.com/nais/aivenator/pkg/aiven/opensearch"
 	"github.com/nais/aivenator/pkg/aiven/service"
 	"github.com/nais/aivenator/pkg/aiven/serviceuser"
 	"github.com/nais/aivenator/pkg/utils"
+	aiven_io_v1alpha1 "github.com/nais/liberator/pkg/apis/aiven.io/v1alpha1"
 	aiven_nais_io_v1 "github.com/nais/liberator/pkg/apis/aiven.nais.io/v1"
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
@@ -67,9 +67,13 @@ func (h OpenSearchHandler) Apply(ctx context.Context, application *aiven_nais_io
 		return nil, nil
 	}
 
-	serviceName, err := h.resolveServiceName(ctx, application.GetNamespace(), spec.Instance)
+	serviceName := spec.Instance
+	belongs, err := h.instanceBelongsToTeam(ctx, application.Namespace, serviceName)
 	if err != nil {
-		utils.LocalFail("ResolveOpenSearchInstance", application, err, logger)
+		utils.LocalFail("VerifyOpenSearchInstanceOwnership", application, err, logger)
+		return nil, err
+	} else if !belongs {
+		err = fmt.Errorf("openSearch instance %q does not belong to team %q", serviceName, application.Namespace)
 		return nil, err
 	}
 
@@ -128,6 +132,21 @@ func (h OpenSearchHandler) Apply(ctx context.Context, application *aiven_nais_io
 
 	logger.Infof("Applied individualSecret")
 	return []corev1.Secret{*individualSecret}, nil
+}
+
+func (h OpenSearchHandler) instanceBelongsToTeam(ctx context.Context, namespace, instanceName string) (bool, error) {
+	newStyleName := fmt.Sprintf("opensearch-%s-%s", namespace, instanceName)
+
+	// Prefer the new-style name; fall back to the legacy instance name when absent.
+	instance, err := utils.GetResourceInNamespace(ctx, h.k8sReader, &aiven_io_v1alpha1.OpenSearch{}, newStyleName, namespace)
+	if errors.Is(err, utils.ErrNotFound) {
+		instance, err = utils.GetResourceInNamespace(ctx, h.k8sReader, &aiven_io_v1alpha1.OpenSearch{}, instanceName, namespace)
+	}
+	if err != nil {
+		return false, err
+	}
+
+	return instance.Spec.Tags["team"] == namespace, nil
 }
 
 func (h OpenSearchHandler) provideServiceUser(ctx context.Context, application *aiven_nais_io_v1.AivenApplication, serviceName string, secret *corev1.Secret, logger log.FieldLogger) (*aiven.ServiceUser, error) {
@@ -254,20 +273,4 @@ func (h OpenSearchHandler) Cleanup(ctx context.Context, secret *corev1.Secret, l
 	}
 
 	return nil
-}
-
-// This function's raison d'être is ONLY for backwards compatibility for opensearch instances from BEFORE we perform "does the instance you want belong to your namespace?" check
-func (h OpenSearchHandler) resolveServiceName(ctx context.Context, namespace, instance string) (string, error) {
-	newStyleName := fmt.Sprintf("opensearch-%s-%s", namespace, instance)
-	if cr, err := utils.GetResourceInNamespace(ctx, h.k8sReader, &aiven_io_v1alpha1.OpenSearch{}, newStyleName, namespace); cr != nil {
-		return newStyleName, nil
-	} else if err != nil && !errors.Is(err, utils.ErrNotFound) {
-		return "", err
-	}
-
-	cr, err := utils.GetResourceInNamespace(ctx, h.k8sReader, &aiven_io_v1alpha1.OpenSearch{}, instance, namespace)
-	if cr != nil {
-		return instance, nil
-	}
-	return "", err
 }

--- a/pkg/services/opensearch/opensearch_test.go
+++ b/pkg/services/opensearch/opensearch_test.go
@@ -7,12 +7,12 @@ import (
 
 	"github.com/aiven/aiven-go-client/v2"
 	"github.com/nais/aivenator/constants"
-	aiven_io_v1alpha1 "github.com/nais/liberator/pkg/apis/aiven.io/v1alpha1"
 	"github.com/nais/aivenator/pkg/aiven/opensearch"
 	"github.com/nais/aivenator/pkg/aiven/project"
 	"github.com/nais/aivenator/pkg/aiven/service"
 	"github.com/nais/aivenator/pkg/aiven/serviceuser"
 	"github.com/nais/aivenator/pkg/utils"
+	aiven_io_v1alpha1 "github.com/nais/liberator/pkg/apis/aiven.io/v1alpha1"
 	aiven_nais_io_v1 "github.com/nais/liberator/pkg/apis/aiven.nais.io/v1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -76,9 +76,18 @@ var _ = Describe("opensearch handler", func() {
 		scheme := runtime.NewScheme()
 		Expect(aiven_io_v1alpha1.AddToScheme(scheme)).To(Succeed())
 		// Pre-populate CRs matching test constants in testNamespace.
+		// The "team" tag must match the namespace, or instanceBelongsToTeam rejects ownership.
 		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
-			&aiven_io_v1alpha1.OpenSearch{ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: testNamespace}, Status: aiven_io_v1alpha1.OpenSearchStatus{State: utils.ReadyState}},
-			&aiven_io_v1alpha1.OpenSearch{ObjectMeta: metav1.ObjectMeta{Name: instance, Namespace: testNamespace}, Status: aiven_io_v1alpha1.OpenSearchStatus{State: utils.ReadyState}},
+			&aiven_io_v1alpha1.OpenSearch{
+				ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: testNamespace},
+				Spec:       aiven_io_v1alpha1.OpenSearchSpec{ServiceCommonSpec: aiven_io_v1alpha1.ServiceCommonSpec{Tags: map[string]string{"team": testNamespace}}},
+				Status:     aiven_io_v1alpha1.OpenSearchStatus{State: utils.ReadyState},
+			},
+			&aiven_io_v1alpha1.OpenSearch{
+				ObjectMeta: metav1.ObjectMeta{Name: instance, Namespace: testNamespace},
+				Spec:       aiven_io_v1alpha1.OpenSearchSpec{ServiceCommonSpec: aiven_io_v1alpha1.ServiceCommonSpec{Tags: map[string]string{"team": testNamespace}}},
+				Status:     aiven_io_v1alpha1.OpenSearchStatus{State: utils.ReadyState},
+			},
 		).Build()
 
 		opensearchHandler = OpenSearchHandler{
@@ -417,18 +426,17 @@ var _ = Describe("opensearch handler", func() {
 				}).
 				Build()
 			mockAivenReturnCaOk()
-			// GetServiceAddresses must be called with the resolved new-style name
-			mocks.serviceManager.On("GetServiceAddresses", mock.Anything, projectName, "opensearch-"+testNamespace+"-roger").
+			mocks.serviceManager.On("GetServiceAddresses", mock.Anything, projectName, "roger").
 				Return(opensearchServiceAddresses, nil)
 			mockAivenReturnOpensearchGetServiceUserOk()
 			mockAivenReturnAclManagerGetOk()
 			mockAivenReturnAclManagerUpdateOk()
 		})
 
-		It("resolves via the new-style CR name and succeeds", func() {
-			// Add the new-style CR to the fake client
+		It("verifies ownership via the new-style CR name and succeeds", func() {
 			cr := &aiven_io_v1alpha1.OpenSearch{
 				ObjectMeta: metav1.ObjectMeta{Name: "opensearch-" + testNamespace + "-roger", Namespace: testNamespace},
+				Spec:       aiven_io_v1alpha1.OpenSearchSpec{ServiceCommonSpec: aiven_io_v1alpha1.ServiceCommonSpec{Tags: map[string]string{"team": testNamespace}}},
 				Status:     aiven_io_v1alpha1.OpenSearchStatus{State: utils.ReadyState},
 			}
 			Expect(opensearchHandler.k8sReader.(client.Client).Create(ctx, cr)).To(Succeed())
@@ -436,7 +444,7 @@ var _ = Describe("opensearch handler", func() {
 			individualSecrets, err := opensearchHandler.Apply(ctx, &application, logger)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(individualSecrets).To(HaveLen(1))
-			Expect(individualSecrets[0].Annotations[ServiceNameAnnotation]).To(Equal("opensearch-" + testNamespace + "-roger"))
+			Expect(individualSecrets[0].Annotations[ServiceNameAnnotation]).To(Equal("roger"))
 		})
 	})
 
@@ -461,16 +469,14 @@ var _ = Describe("opensearch handler", func() {
 		})
 	})
 
-	// Namespace naming collision: opensearch-<ns>-<instance> is ambiguous.
-	// e.g. namespace "a" + instance "b-foo" and namespace "a-b" + instance "foo"
-	// both produce "opensearch-a-b-foo". Aiven rejects the duplicate, so the
-	// colliding CR exists in-cluster but never reaches RUNNING.
-	When("OpenSearch CR exists in namespace but is NOT in RUNNING state (naming collision)", func() {
+	// Ownership requires the CR's "team" tag to match the namespace of requesting aivenapp, not merely that the CR exists and is RUNNING.
+	// A RUNNING CR tagged for a different team must be rejected.
+	When("the OpenSearch CR's team tag does not match the aivenapp's namespace", func() {
 		BeforeEach(func() {
-			// CR exists in testNamespace with a non-RUNNING state (simulates Aiven rejection)
 			cr := &aiven_io_v1alpha1.OpenSearch{
 				ObjectMeta: metav1.ObjectMeta{Name: "opensearch-" + testNamespace + "-collided", Namespace: testNamespace},
-				Status:     aiven_io_v1alpha1.OpenSearchStatus{State: "NOT_RUNNING"},
+				Status:     aiven_io_v1alpha1.OpenSearchStatus{State: "RUNNING"},
+				Spec:       aiven_io_v1alpha1.OpenSearchSpec{ServiceCommonSpec: aiven_io_v1alpha1.ServiceCommonSpec{Tags: map[string]string{"team": "innocent-team"}}},
 			}
 			Expect(opensearchHandler.k8sReader.(client.Client).Create(ctx, cr)).To(Succeed())
 
@@ -485,10 +491,10 @@ var _ = Describe("opensearch handler", func() {
 				Build()
 		})
 
-		It("rejects because the instance is not RUNNING", func() {
+		It("rejects because the instance does not belong to aivenapp team", func() {
 			_, err := opensearchHandler.Apply(ctx, &application, logger)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("expected RUNNING"))
+			Expect(err.Error()).To(ContainSubstring("does not belong to team"))
 		})
 	})
 

--- a/pkg/services/valkey/valkey.go
+++ b/pkg/services/valkey/valkey.go
@@ -10,10 +10,10 @@ import (
 
 	"github.com/aiven/aiven-go-client/v2"
 	"github.com/nais/aivenator/constants"
-	aiven_io_v1alpha1 "github.com/nais/liberator/pkg/apis/aiven.io/v1alpha1"
 	"github.com/nais/aivenator/pkg/aiven/service"
 	"github.com/nais/aivenator/pkg/aiven/serviceuser"
 	"github.com/nais/aivenator/pkg/utils"
+	aiven_io_v1alpha1 "github.com/nais/liberator/pkg/apis/aiven.io/v1alpha1"
 	aiven_nais_io_v1 "github.com/nais/liberator/pkg/apis/aiven.nais.io/v1"
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
@@ -66,6 +66,16 @@ type ValkeyHandler struct {
 	k8sReader    client.Reader
 }
 
+func (h ValkeyHandler) instanceBelongsToTeam(ctx context.Context, namespace, instanceName string) (bool, error) {
+	instance := &aiven_io_v1alpha1.Valkey{}
+	instance, err := utils.GetResourceInNamespace(ctx, h.k8sReader, instance, instanceName, namespace)
+	if err != nil {
+		return false, err
+	}
+
+	return instance.Spec.Tags["team"] == namespace, nil
+}
+
 func (h ValkeyHandler) Apply(ctx context.Context, application *aiven_nais_io_v1.AivenApplication, logger log.FieldLogger) ([]corev1.Secret, error) {
 	logger = logger.WithFields(log.Fields{"handler": "valkey"})
 	if len(application.Spec.Valkey) == 0 {
@@ -76,8 +86,12 @@ func (h ValkeyHandler) Apply(ctx context.Context, application *aiven_nais_io_v1.
 	for _, valkeySpec := range application.Spec.Valkey {
 		serviceName := fmt.Sprintf("valkey-%s-%s", application.GetNamespace(), valkeySpec.Instance)
 
-		if _, err := utils.GetResourceInNamespace(ctx, h.k8sReader, &aiven_io_v1alpha1.Valkey{}, serviceName, application.GetNamespace()); err != nil {
-			utils.LocalFail("ResolveValkeyInstance", application, err, logger)
+		belongs, err := h.instanceBelongsToTeam(ctx, application.Namespace, serviceName)
+		if err != nil {
+			utils.LocalFail("VerifyValkeyInstanceOwnership", application, err, logger)
+			return nil, err
+		} else if !belongs {
+			err = fmt.Errorf("valkey instance %q does not belong to team %q", serviceName, application.Namespace)
 			return nil, err
 		}
 
@@ -92,7 +106,7 @@ func (h ValkeyHandler) Apply(ctx context.Context, application *aiven_nais_io_v1.
 				Namespace: application.GetNamespace(),
 			},
 		}
-		_, err := h.secretConfig.ApplyIndividualSecret(ctx, application, finalSecret, logger)
+		_, err = h.secretConfig.ApplyIndividualSecret(ctx, application, finalSecret, logger)
 		if err != nil {
 			return nil, utils.AivenFail("GetOrInitSecret", application, err, false, logger)
 		}

--- a/pkg/services/valkey/valkey_test.go
+++ b/pkg/services/valkey/valkey_test.go
@@ -8,11 +8,11 @@ import (
 	"time"
 
 	"github.com/aiven/aiven-go-client/v2"
-	aiven_io_v1alpha1 "github.com/nais/liberator/pkg/apis/aiven.io/v1alpha1"
 	"github.com/nais/aivenator/pkg/aiven/project"
 	"github.com/nais/aivenator/pkg/aiven/service"
 	"github.com/nais/aivenator/pkg/aiven/serviceuser"
 	"github.com/nais/aivenator/pkg/utils"
+	aiven_io_v1alpha1 "github.com/nais/liberator/pkg/apis/aiven.io/v1alpha1"
 	aiven_nais_io_v1 "github.com/nais/liberator/pkg/apis/aiven.nais.io/v1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -232,9 +232,21 @@ var _ = Describe("valkey.SecretConfig", func() {
 		Expect(aiven_io_v1alpha1.AddToScheme(scheme)).To(Succeed())
 		// Pre-populate Valkey CRs matching testInstances in namespace "team-a"
 		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
-			&aiven_io_v1alpha1.Valkey{ObjectMeta: metav1.ObjectMeta{Name: "valkey-team-a-my-instance1", Namespace: namespace}, Status: aiven_io_v1alpha1.ValkeyStatus{State: utils.ReadyState}},
-			&aiven_io_v1alpha1.Valkey{ObjectMeta: metav1.ObjectMeta{Name: "valkey-team-a-session-store", Namespace: namespace}, Status: aiven_io_v1alpha1.ValkeyStatus{State: utils.ReadyState}},
-			&aiven_io_v1alpha1.Valkey{ObjectMeta: metav1.ObjectMeta{Name: "valkey-team-a-with-replica", Namespace: namespace}, Status: aiven_io_v1alpha1.ValkeyStatus{State: utils.ReadyState}},
+			&aiven_io_v1alpha1.Valkey{
+				ObjectMeta: metav1.ObjectMeta{Name: "valkey-team-a-my-instance1", Namespace: namespace},
+				Spec:       aiven_io_v1alpha1.ValkeySpec{ServiceCommonSpec: aiven_io_v1alpha1.ServiceCommonSpec{Tags: map[string]string{"team": namespace}}},
+				Status:     aiven_io_v1alpha1.ValkeyStatus{State: utils.ReadyState},
+			},
+			&aiven_io_v1alpha1.Valkey{
+				ObjectMeta: metav1.ObjectMeta{Name: "valkey-team-a-session-store", Namespace: namespace},
+				Spec:       aiven_io_v1alpha1.ValkeySpec{ServiceCommonSpec: aiven_io_v1alpha1.ServiceCommonSpec{Tags: map[string]string{"team": namespace}}},
+				Status:     aiven_io_v1alpha1.ValkeyStatus{State: utils.ReadyState},
+			},
+			&aiven_io_v1alpha1.Valkey{
+				ObjectMeta: metav1.ObjectMeta{Name: "valkey-team-a-with-replica", Namespace: namespace},
+				Spec:       aiven_io_v1alpha1.ValkeySpec{ServiceCommonSpec: aiven_io_v1alpha1.ServiceCommonSpec{Tags: map[string]string{"team": namespace}}},
+				Status:     aiven_io_v1alpha1.ValkeyStatus{State: utils.ReadyState},
+			},
 		).Build()
 
 		valkeyHandler = ValkeyHandler{
@@ -495,6 +507,39 @@ var _ = Describe("valkey.SecretConfig", func() {
 			_, err := valkeyHandler.Apply(ctx, &application, logger)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("expected RUNNING"))
+		})
+	})
+
+	// Ownership requires the CR's "team" tag to equal the requesting aivenapp's namespace, not merely that the CR exists and is RUNNING.
+	// Flattened valkey-<ns>-<instance> names can collide across teams whose names are substrings of one another —
+	// e.g. namespace "team-a" + instance "b-cache" and namespace "team-a-b" + instance "cache" both yield "valkey-team-a-b-cache" —
+	// so a RUNNING CR tagged for another team must be rejected.
+	When("the Valkey CR's team tag does not match the aivenapp's namespace", func() {
+		BeforeEach(func() {
+			cr := &aiven_io_v1alpha1.Valkey{
+				ObjectMeta: metav1.ObjectMeta{Name: "valkey-team-a-b-cache", Namespace: namespace},
+				Status:     aiven_io_v1alpha1.ValkeyStatus{State: utils.ReadyState},
+				Spec:       aiven_io_v1alpha1.ValkeySpec{ServiceCommonSpec: aiven_io_v1alpha1.ServiceCommonSpec{Tags: map[string]string{"team": "team-a-b"}}},
+			}
+			Expect(valkeyHandler.k8sReader.(client.Client).Create(ctx, cr)).To(Succeed())
+
+			application = applicationBuilder.
+				WithSpec(aiven_nais_io_v1.AivenApplicationSpec{
+					Valkey: []*aiven_nais_io_v1.ValkeySpec{
+						{
+							Instance:   "b-cache",
+							Access:     "read",
+							SecretName: "b-cache-secret",
+						},
+					},
+				}).
+				Build()
+		})
+
+		It("rejects because the instance does not belong to aivenapp team", func() {
+			_, err := valkeyHandler.Apply(ctx, &application, logger)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("does not belong to team"))
 		})
 	})
 

--- a/pkg/utils/instance_validation.go
+++ b/pkg/utils/instance_validation.go
@@ -16,21 +16,22 @@ const (
 // GetResourceInNamespace fetches a CR by name and namespace, and verifies
 // that its status.state is "RUNNING".
 // Returns (obj, nil) when found and running, (nil, err) otherwise.
-func GetResourceInNamespace(ctx context.Context, reader client.Reader, obj client.Object, name, namespace string) (client.Object, error) {
+func GetResourceInNamespace[T client.Object](ctx context.Context, reader client.Reader, obj T, name, namespace string) (T, error) {
+	var zero T
 	err := reader.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, obj)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
-			return nil, fmt.Errorf("%T %q not found in namespace %q: %w", obj, name, namespace, ErrNotFound)
+			return zero, fmt.Errorf("%T %q not found in namespace %q: %w", obj, name, namespace, ErrNotFound)
 		}
-		return nil, fmt.Errorf("failed to look up %T %q in namespace %q: %w", obj, name, namespace, err)
+		return zero, fmt.Errorf("failed to look up %T %q in namespace %q: %w", obj, name, namespace, err)
 	}
 
 	state, err := extractState(obj)
 	if err != nil {
-		return nil, fmt.Errorf("%T %q in namespace %q: %w", obj, name, namespace, err)
+		return zero, fmt.Errorf("%T %q in namespace %q: %w", obj, name, namespace, err)
 	}
 	if state != ReadyState {
-		return nil, fmt.Errorf("%T %q in namespace %q has state %q, expected "+ReadyState+": %w",
+		return zero, fmt.Errorf("%T %q in namespace %q has state %q, expected "+ReadyState+": %w",
 			obj, name, namespace, state, ErrNotReady)
 	}
 	return obj, nil


### PR DESCRIPTION
Instead of checking k8s resource existence in namespace + status alone.
Pro: ownership tags should always be set
Cons: new (implicit) connection to another piece of nais platform infrastructure (github.com/nais/mutilator)
